### PR TITLE
update fix pvc

### DIFF
--- a/charts/common/templates/_pvc.yaml
+++ b/charts/common/templates/_pvc.yaml
@@ -1,6 +1,6 @@
 {{- define "common.pvc.tpl" -}}
 {{- range .Values.volumes }}
-{{- if not (or .existingClaim .hostPath .fileName .emptyDir .existingConfigMap) }}
+{{- if not (or .existingClaim .hostPath .fileName .emptyDir .existingConfigMap .existingSecret) }}
 {{- $robustName := include "common.robustName" $.Release.Name }}
 ---
 apiVersion: v1

--- a/charts/onechart/tests/pvc_test.yaml
+++ b/charts/onechart/tests/pvc_test.yaml
@@ -46,3 +46,12 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: Should not generate a claim when using existingSecret
+    set:
+      volumes:
+        - name: data
+          path: /var/lib/1clickinfra/data
+          existingSecret: my-existing-secret
+    asserts:
+      - hasDocuments:
+          count: 0   


### PR DESCRIPTION
For volumes, if an existingSecret is specified, a PersistentVolumeClaim (PVC) will not be created.